### PR TITLE
Add sale_bom_split_dropshipping: compatibility module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ virtualenv:
 install:
   - git clone https://github.com/OCA/stock-logistics-warehouse ${HOME}/stock-logistics-warehouse -b ${VERSION}
   - git clone https://github.com/OCA/sale-workflow ${HOME}/sale-workflow -b ${VERSION}
+  - git clone https://github.com/OCA/purchase-workflow ${HOME}/purchase-workflow -b ${VERSION}
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ virtualenv:
 
 install:
   - git clone https://github.com/OCA/stock-logistics-warehouse ${HOME}/stock-logistics-warehouse -b ${VERSION}
+  - git clone https://github.com/OCA/sale-workflow ${HOME}/sale-workflow -b ${VERSION}
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly

--- a/sale_bom_split_dropshipping/__init__.py
+++ b/sale_bom_split_dropshipping/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import model

--- a/sale_bom_split_dropshipping/__openerp__.py
+++ b/sale_bom_split_dropshipping/__openerp__.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{'name': 'Sales BoMs Split - Dropshipping (compatibility)',
+ 'version': '1.0',
+ 'author': 'Camptocamp',
+ 'maintainer': 'Camptocamp',
+ 'license': 'AGPL-3',
+ 'category': 'Sales & Purchases',
+ 'depends': ['sale_bom_split',
+             # https://github.com/OCA/sale-workflow/tree/7.0
+             'sale_dropshipping',
+             ],
+ 'description': """
+Sales BoMs Split - Dropshipping (compatibility)
+===============================================
+
+Compatibility module between **Sales BoM Split** and
+**Sale Dropshipping**.
+
+When a line with a Bill of Material in a sales order has
+a drop shipping setup, the procurements generated for the
+components will also be in drop shipping.
+
+ """,
+ 'website': 'http://www.camptocamp.com',
+ 'data': [],
+ 'test': [],
+ 'installable': True,
+ 'auto_install': True,
+ }

--- a/sale_bom_split_dropshipping/model/__init__.py
+++ b/sale_bom_split_dropshipping/model/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_order

--- a/sale_bom_split_dropshipping/model/sale_order.py
+++ b/sale_bom_split_dropshipping/model/sale_order.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class SaleOrder(orm.Model):
+    _inherit = 'sale.order'
+
+    def _create_components_procurements_direct_mto(self, cr, uid, order,
+                                                   order_lines, context=None):
+        proc_obj = self.pool['procurement.order']
+        uom_obj = self.pool['product.uom']
+        bom_obj = self.pool['mrp.bom']
+
+        proc_ids = []
+        for line, bom in order_lines:
+            factor = uom_obj._compute_qty_obj(cr, uid,
+                                              line.product_uom,
+                                              line.product_uom_qty,
+                                              bom.product_uom)
+            bom_components = bom_obj.bom_split(cr, uid, bom, factor)
+
+            date_planned = self._get_date_planned(
+                cr, uid, order, line, order.date_order, context=context)
+
+            first_component = None
+            for component in bom_components:
+                vals = self._prepare_order_line_split_procurement(
+                    cr, uid, order, line, component,
+                    False, date_planned, context=context
+                )
+                proc_id = proc_obj.create(cr, uid, vals, context=context)
+                proc_ids.append(proc_id)
+                if first_component is None:
+                    first_component = proc_id
+
+            # The sale order line could be linked only
+            # to 1 procurement, so we link it with
+            # the first procurement.
+            line.write({'procurement_id': first_component})
+        return proc_ids
+
+    def _create_components_moves_and_procurements(self, cr, uid, order,
+                                                  order_lines,
+                                                  picking_id=False,
+                                                  context=None):
+        normal_lines = []
+        dropship_lines = []
+        dropship_flows = ('direct_delivery', 'direct_invoice_and_delivery')
+        for line, bom in order_lines:
+            if (line.type == 'make_to_order' and
+                    line.sale_flow in dropship_flows):
+                dropship_lines.append((line, bom))
+            else:
+                normal_lines.append((line, bom))
+        proc_ids = self._create_components_procurements_direct_mto(
+            cr, uid, order,
+            dropship_lines,
+            context=context
+        )
+
+        _super = super(SaleOrder, self)
+        _super_create = _super._create_components_moves_and_procurements
+        new_proc_ids, picking_id = _super_create(
+            cr, uid, order, normal_lines,
+            picking_id=picking_id, context=context
+        )
+        proc_ids += new_proc_ids
+        return proc_ids, picking_id


### PR DESCRIPTION
Between sale_bom_split and sale_dropshipping.
- _sale_bom_split_ splits the bill of materials in the delivery orders when a sales order is confirmed
- _sale_dropshipping_ allows to use dropshipping on sales order lines (no picking, creates "on order" procurements)

When both modules are installed, the components of the BoM are added in the normal picking even if the line is set to "dropshipping". With this compatibility module, the components are well considered as dropshipped and are not added in the picking, but have "on order" procurements.
